### PR TITLE
Add categories CRUD support

### DIFF
--- a/backend/app/api/endpoints/categories.py
+++ b/backend/app/api/endpoints/categories.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Form
 from app.database import SessionLocal
 from app.models.models import Category
 
@@ -10,3 +10,13 @@ def get_categories():
     categories = db.query(Category).all()
     db.close()
     return categories
+
+@router.post("/categories/")
+def create_category(name: str = Form(...)):
+    db = SessionLocal()
+    new_category = Category(name=name)
+    db.add(new_category)
+    db.commit()
+    db.refresh(new_category)
+    db.close()
+    return new_category

--- a/frontend/app/src/App.js
+++ b/frontend/app/src/App.js
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Home from './views/Home';
 import CreateRiff from './views/CreateRiff';
+import CreateCategory from './views/CreateCategory';
 import Header from './components/Header';
 
 // Placeholder for now if CreateSong and CreateCategory are not built yet
@@ -16,7 +17,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/create-riff" element={<CreateRiff />} />
         <Route path="/create-song" element={<Placeholder text="Create Song (Coming Soon)" />} />
-        <Route path="/create-category" element={<Placeholder text="Create Category (Coming Soon)" />} />
+        <Route path="/create-category" element={<CreateCategory />} />
       </Routes>
     </Router>
   );

--- a/frontend/app/src/services/api.js
+++ b/frontend/app/src/services/api.js
@@ -15,6 +15,22 @@ export async function getCategories() {
   return response.json();
 }
 
+export async function createCategory(name) {
+  const formData = new FormData();
+  formData.append('name', name);
+
+  const response = await fetch(`${BASE_URL}/categories/`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error('Creation failed');
+  }
+
+  return await response.json();
+}
+
 export async function uploadRiff(file, name, category) {
     const formData = new FormData();
     formData.append("file", file);

--- a/frontend/app/src/views/CreateCategory.jsx
+++ b/frontend/app/src/views/CreateCategory.jsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { createCategory } from '../services/api';
+import { Link } from 'react-router-dom';
+
+function CreateCategory() {
+  const [name, setName] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSave = async () => {
+    if (!name) {
+      alert('Please enter a name');
+      return;
+    }
+    try {
+      setIsSaving(true);
+      await createCategory(name);
+      alert('Category created successfully!');
+      setName('');
+    } catch (e) {
+      console.error(e);
+      alert('Creation failed.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div style={{ padding: '40px', maxWidth: '800px', margin: '0 auto' }}>
+      <div style={{ marginBottom: '30px' }}>
+        <Link to="/">
+          <button>← Back to Home</button>
+        </Link>
+      </div>
+
+      <h1 style={{ fontSize: '32px', marginBottom: '40px' }}>Create New Category</h1>
+
+      <div style={{ marginBottom: '20px' }}>
+        <label>Category Name</label><br />
+        <input
+          type="text"
+          placeholder="Enter category name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          style={{ width: '100%', padding: '10px', marginTop: '8px' }}
+        />
+      </div>
+
+      <button onClick={handleSave} disabled={isSaving} style={{ width: '100%', padding: '12px', fontSize: '16px' }}>
+        {isSaving ? 'Saving...' : 'Save Category'}
+      </button>
+    </div>
+  );
+}
+
+export default CreateCategory;

--- a/frontend/app/src/views/CreateRiff.jsx
+++ b/frontend/app/src/views/CreateRiff.jsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useRef } from 'react';
-import { uploadRiff } from '../services/api';
+import { uploadRiff, getCategories } from '../services/api';
 import { Link } from 'react-router-dom';
 
 function CreateRiff() {
   const [name, setName] = useState('');
   const [category, setCategory] = useState('');
+  const [categories, setCategories] = useState([]);
   const [file, setFile] = useState(null);
   const [previewUrl, setPreviewUrl] = useState(null);
   const [isUploading, setIsUploading] = useState(false);
@@ -21,6 +22,10 @@ function CreateRiff() {
   const mediaRecorderRef = useRef(null);
   const audioStreamRef = useRef(null);
   const timerRef = useRef(null);
+
+  useEffect(() => {
+    getCategories().then(setCategories);
+  }, []);
 
   const handleFileChange = (e) => {
     const selected = e.target.files[0];
@@ -144,13 +149,16 @@ function CreateRiff() {
 
           <div style={{ marginBottom: '20px' }}>
             <label>Category</label><br />
-            <input
-              type="text"
-              placeholder="Optional category"
+            <select
               value={category}
               onChange={(e) => setCategory(e.target.value)}
               style={{ width: '100%', padding: '10px', marginTop: '8px' }}
-            />
+            >
+              <option value="">Uncategorized</option>
+              {categories.map((cat) => (
+                <option key={cat.id} value={cat.name}>{cat.name}</option>
+              ))}
+            </select>
           </div>
 
           <div style={{ marginBottom: '20px' }}>


### PR DESCRIPTION
## Summary
- allow creating categories in the backend
- expose createCategory API helper
- add CreateCategory view and route
- fetch categories in CreateRiff and use dropdown

## Testing
- `pytest`
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*