### PR TITLE
Fix webm uploads and requirements cleanup

### DIFF
--- a/backend/app/api/endpoints/riffs.py
+++ b/backend/app/api/endpoints/riffs.py
@@ -20,7 +20,7 @@ async def upload_riff(
     name: str = Form("Unnamed"),
     category: str = Form("Uncategorized")
 ):
-    if not file.filename.endswith((".mp3", ".wav")):
+    if not file.filename.endswith((".mp3", ".wav", ".webm")):
         raise HTTPException(status_code=400, detail="Invalid file type")
     
     os.makedirs(UPLOAD_DIR, exist_ok=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,10 +15,8 @@ sniffio==1.3.1
 starlette==0.46.2
 typing-inspection==0.4.0
 typing_extensions==4.13.2
-uvicorn==0.34.2
 watchfiles==1.0.5
 websockets==15.0.1
 sqlalchemy
 python-multipart
-fastapi
-uvicorn[standard]
+uvicorn[standard]==0.34.2


### PR DESCRIPTION
## Summary
- allow uploading .webm files
- clean up backend requirements

## Testing
- `python -m compileall backend/app`
- `pytest -q`
- `npm test --silent` *(fails: react-scripts not found)*